### PR TITLE
Enter key by user to validate the setting

### DIFF
--- a/CRM/Mailchimp/Form/Setting.php
+++ b/CRM/Mailchimp/Form/Setting.php
@@ -16,6 +16,11 @@ class CRM_Mailchimp_Form_Setting extends CRM_Core_Form {
     $this->addElement('text', 'api_key', ts('API Key'), array(
       'size' => 48,
     ));
+    
+    // Add the User Security Key Element    
+    $this->addElement('text','security_key',ts('Security Key'), array(
+        'size'=> 24,
+    ));
 
     // Create the Submit Button.
     $buttons = array(
@@ -35,7 +40,11 @@ class CRM_Mailchimp_Form_Setting extends CRM_Core_Form {
     $apiKey = CRM_Core_BAO_Setting::getItem(self::MC_SETTING_GROUP,
       'api_key', NULL, FALSE
     );
+    $securityKey = CRM_Core_BAO_Setting::getItem(self::MC_SETTING_GROUP,
+      'security_key', NULL, FALSE
+    );
     $defaults['api_key'] = $apiKey;
+    $defaults['security_key'] =  $securityKey;
 
     return $defaults;
   }
@@ -56,7 +65,16 @@ class CRM_Mailchimp_Form_Setting extends CRM_Core_Form {
       CRM_Core_BAO_Setting::setItem($params['api_key'],
         self::MC_SETTING_GROUP,
         'api_key'
+      );      
+      
+      // Save the Security Key
+      if (CRM_Utils_Array::value('security_key', $params)) {
+      CRM_Core_BAO_Setting::setItem($params['security_key'],
+        self::MC_SETTING_GROUP,
+        'security_key'
       );
+      }
+      
       try {
         $mcClient = new Mailchimp($params['api_key']);
         $mcHelper = new Mailchimp_Helper($mcClient);

--- a/CRM/Mailchimp/Page/WebHook.php
+++ b/CRM/Mailchimp/Page/WebHook.php
@@ -1,0 +1,123 @@
+<?php
+class CRM_Mailchimp_Page_WebHook extends CRM_Core_Page {
+    const 
+    MC_SETTING_GROUP = 'MailChimp Preferences';
+
+  function run() {
+      
+      $my_key = CRM_Core_BAO_Setting::getItem(self::MC_SETTING_GROUP,
+      'security_key', NULL, FALSE
+    );
+
+
+if (isset($_GET['key']) && $_GET['key']==$my_key){    
+     
+    if(!empty($_POST['data']['list_id']) && !empty($_POST['type'])) {
+    	$requestType = $_POST['type'];
+    	$requestData = $_POST['data'];
+      
+      // Mailchimp Subscribe event
+      if($requestType == 'subscribe' OR $requestType == 'unsubscribe') {
+        
+        // Create/Update contact details in CiviCRM
+        $contactID = CRM_Mailchimp_Utils::updateContactDetails($requestData['merges']);
+        
+        // Subscribe/Unsubscribe to related CiviCRM groups 
+        self::manageCiviCRMGroupSubcription($contactID , $requestData , $requestType);
+      }
+      
+      // Mailchimp Email Update event
+      else if($requestType == 'profile') {
+        
+        // Create/Update contact details in CiviCRM
+        $contactID = CRM_Mailchimp_Utils::updateContactDetails($requestData['merges']);
+        $contactArray = array($contactID);
+        
+        $listID = $requestData['list_id'];
+        $mcGroupings = $requestData['merges']['GROUPINGS'];
+        
+        // Get the associated CiviCRM Group IDs for the Mailchimp List & Grouping
+        $civiGroups = CRM_Mailchimp_Utils::getCiviGroupIdsforMcGroupings($listID, $mcGroupings);
+        // Get all CiviCRM groups which are mapped to the Mailchimp List, to which the contact is added to
+        $contactGroups = CRM_Mailchimp_Utils::getGroupSubscriptionforMailchimpList($listID , $contactID);
+        
+        // Contact is added to any group in Mailchimp, we also need to add the contact to CiviCRM group
+        $addedGroups = array_diff($civiGroups , $contactGroups);
+        if (!empty($addedGroups)) {
+          foreach ($addedGroups as $key => $groupID) {
+            CRM_Contact_BAO_GroupContact::addContactsToGroup($contactArray, $groupID, 'Admin', 'Added');
+          }
+        }
+        
+        // Contact is removed from any group in Mailchimp, we also need to remove the contact from CiviCRM group
+        $removedGroups = array_diff($contactGroups, $civiGroups);
+        if (!empty($removedGroups)) {
+          foreach ($removedGroups as $key => $groupID) {
+            CRM_Contact_BAO_GroupContact::removeContactsFromGroup($contactArray, $groupID, 'Admin', 'Removed');
+          }
+        }
+      }
+      
+      // Mailchimp Email Update event
+      else if($requestType == 'upemail') {
+        // Try to find the email address
+        $email = new CRM_Core_BAO_Email();
+        $email->get('email', $requestData['old_email']);
+
+        // If the Email was found.
+        if (!empty($email->contact_id)) {
+          $email->email = $requestData['new_email'];
+          $email->save();
+        }
+      }
+
+      // Mailchimp Cleaned Email  event
+      else if($requestType == 'cleaned') {
+        // Try to find the email address
+        $email = new CRM_Core_BAO_Email();
+        $email->get('email', $requestData['email']);
+
+        // If the Email was found.
+        if (!empty($email->contact_id)) {
+          $email->on_hold = 1;
+          $email->holdEmail($email);
+        }
+      }
+    }
+}
+
+    // Return the JSON output
+    header('Content-type: application/json');
+    print json_encode($data);
+    CRM_Utils_System::civiExit();
+  } 
+  
+  /*
+   * Add/Remove contact from CiviCRM Groups mapped with Mailchimp List & Groups 
+   */
+  static function manageCiviCRMGroupSubcription($contactID , $requestData , $action) {
+    if (empty($contactID) || empty($requestData['merges']['GROUPINGS']) || empty($requestData['list_id']) || empty($action)) {
+      return NULL;
+    }
+    
+    $listID = $requestData['list_id'];
+    
+    $mcGroupings = $requestData['merges']['GROUPINGS'];
+    
+    // Get the associated CiviCRM Group IDs for the Mailchimp List & Grouping
+    $civiGroups = CRM_Mailchimp_Utils::getCiviGroupIdsforMcGroupings($listID, $mcGroupings);
+    
+    // Add or Remove from the CiviCRM Groups
+    foreach ($civiGroups as $key => $groupID) {
+      if ($action == 'subscribe') {
+        CRM_Contact_BAO_GroupContact::addContactsToGroup(array($contactID), $groupID, 'Admin', 'Added');
+      }
+
+      // Remove the contact from CiviCRM group
+      if ($action == 'unsubscribe') {
+        CRM_Contact_BAO_GroupContact::removeContactsFromGroup(array($contactID), $groupID, 'Admin', 'Removed');
+      }
+    }
+  } 
+  
+}

--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -82,4 +82,142 @@ class CRM_Mailchimp_Utils {
     }
     return $mapper[$listID][$groupingID][$groupID];
   }
+  
+  /*
+   * Get Mailchimp group ID group name
+   */
+  static function getMailchimpGroupIdFromName($listID, $groupName) {
+    if (empty($listID) || empty($groupName)) {
+      return NULL;
+    }
+
+    $mcLists = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
+    try {
+      $results = $mcLists->interestGroupings($listID);
+    } 
+    catch (Exception $e) {
+      return NULL;
+    }
+    
+    foreach ($results as $grouping) {
+      foreach ($grouping['groups'] as $group) {
+        if ($group['name'] == $groupName) {
+          return $group['id'];
+        }
+      }
+    }
+  }
+  
+  static function getGroupIdForMailchimp($listID, $groupingID, $groupID) {
+    if (empty($listID) || empty($groupingID) || empty($groupID)) {
+      return NULL;
+    }
+
+    $query  = "
+      SELECT  entity_id
+      FROM    civicrm_value_mailchimp_settings mcs
+      WHERE   mc_list_id = %1 AND mc_grouping_id = %2 AND mc_group_id = %3";
+    $params = 
+        array(
+          '1' => array($listID , 'String'),
+          '2' => array($groupingID , 'String'),
+          '3' => array($groupID , 'String'),
+        );
+    $dao = CRM_Core_DAO::executeQuery($query, $params);
+    if ($dao->fetch()) {
+      return $dao->entity_id;
+    }
+  }
+  
+  /*
+   * Create/Update contact details in CiviCRM, based on the data from Mailchimp webhook
+   */
+  static function updateContactDetails($params) {
+    if (empty($params)) {
+      return NULL;
+    }
+
+    $contactParams = 
+        array(
+          'version'       => 3,
+          'contact_type'  => 'Individual',
+          'first_name'    => $params['FNAME'],
+          'last_name'     => $params['LNAME'],
+          'email'         => $params['EMAIL'],
+        );
+    
+    $email = new CRM_Core_BAO_Email();
+		$email->get('email', $params['EMAIL']);
+    
+    // If the Email was found.
+    if (!empty($email->contact_id)) {
+      $contactParams['id'] = $email->contact_id;
+    }
+    
+    // Create/Update Contact details
+    $contactResult = civicrm_api('Contact' , 'create' , $contactParams);
+    
+    return $contactResult['id'];
+  }
+  
+  /*
+   * Function to get the associated CiviCRM Groups IDs for the Grouping array sent from Mialchimp Webhook
+   */
+  static function getCiviGroupIdsforMcGroupings($listID, $mcGroupings) {
+    if (empty($listID) || empty($mcGroupings)) {
+      return NULL;
+    }
+    
+    $civiGroups = array();
+    foreach ($mcGroupings as $key => $mcGrouping) {
+      $mcGroups = @explode(',', $mcGrouping['groups']);
+      foreach ($mcGroups as $mcGroupKey => $mcGroupName) {
+        // Get Mailchimp group ID from group name. Only group name is passed in by Webhooks
+        $mcGroupID = self::getMailchimpGroupIdFromName($listID, trim($mcGroupName));
+        // Mailchimp group ID is unavailable
+        if (empty($mcGroupID)) {
+          break;
+        }
+        
+        // Find the CiviCRM group mapped with the Mailchimp List and Group
+        $civiGroupID = self::getGroupIdForMailchimp($listID, $mcGrouping['id'] , $mcGroupID);
+        if (!empty($civiGroupID)) {
+          $civiGroups[] = $civiGroupID;
+        }
+      }
+    }
+   
+    return $civiGroups;
+  } 
+  
+  /*
+   * Function to get CiviCRM Groups for the specific Mailchimp list in which the Contact is Added to
+   */
+  static function getGroupSubscriptionforMailchimpList($listID, $contactID) {
+    if (empty($listID) || empty($contactID)) {
+      return NULL;
+    }
+    
+    $civiMcGroups = array();
+    $query  = "
+      SELECT  entity_id
+      FROM    civicrm_value_mailchimp_settings mcs
+      WHERE   mc_list_id = %1";
+    $params = array('1' => array($listID, 'String'));
+    
+    $dao = CRM_Core_DAO::executeQuery($query ,$params);
+    while ($dao->fetch()) {
+      $groupContact = new CRM_Contact_BAO_GroupContact();
+      $groupContact->group_id = $dao->entity_id;
+      $groupContact->contact_id = $contactID;
+      $groupContact->whereAdd("status = 'Added'");
+      $groupContact->find();
+      if ($groupContact->fetch()) {
+        $civiMcGroups[] = $dao->entity_id;
+      }
+    }
+   
+    return $civiMcGroups;
+  }
+  
 }

--- a/api/v3/Mailchimp.php
+++ b/api/v3/Mailchimp.php
@@ -81,8 +81,9 @@ function civicrm_api3_mailchimp_getlistsandgroups($params) {
 
     $params = array('id' => $list['id']);
     $group_results = civicrm_api3_mailchimp_getgroups($params);
-
-    $lists[$list['id']]['grouping'] = $group_results['values'];
+    if (!empty($group_results)) {
+      $lists[$list['id']]['grouping'] = $group_results['values'];
+    }
   }
 
   return civicrm_api3_create_success($lists);

--- a/info.xml
+++ b/info.xml
@@ -2,20 +2,23 @@
 <extension key="uk.co.vedaconsulting.mailchimp" type="module">
   <file>mailchimp</file>
   <name>Mailchimp</name>
-  <description>Integration with Mailchimp.</description>
+  <description>CiviCRM and Mailchimp Integration.</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Deepak Srivastava</author>
-    <email>deepak.srivastava.0303@gmail.com</email>
+    <author>Deepak Srivastava, Rajesh Sundararajan and Parvez Saleh</author>
+    <email>support@vedaconsulting.co.uk</email>
   </maintainer>
-  <releaseDate>1</releaseDate>
-  <version>1.0</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2014-04-29</releaseDate>
+  <version>1.0-beta1</version>
+  <develStage>beta</develStage>
   <compatibility>
     <ver>4.4</ver>
   </compatibility>
-  <comments>This is a new, undeveloped module</comments>
+  <comments>Developed by Veda Consulting LTD. Builds on existing work done by Science Gallery.</comments>
   <civix>
     <namespace>CRM/Mailchimp</namespace>
   </civix>
+  <urls>
+    <url desc="Documentation">http://www.vedaconsulting.co.uk/technical/civicrm-mailchimp</url>
+  </urls>
 </extension>

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -200,3 +200,22 @@ function mailchimp_civicrm_buildForm($formName, &$form) {
     }
   }
 }
+
+/**
+ * Implementation of hook_civicrm_pageRun
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_pageRun
+ */
+function mailchimp_civicrm_pageRun( &$page ) {
+  if ($page->getVar('_name') == 'CRM_Group_Page_Group') {
+    $params = array(
+      'version' => 3,
+      'sequential' => 1,
+    );
+    // Get all the mailchimp lists/groups and pass it to template as JS array
+    // To reduce the no. of AJAX calls to get the list/group name in Group Listing Page
+    $result = civicrm_api('Mailchimp', 'getlistsandgroups', $params);
+    $list_and_groups = json_encode($result['values']);
+    $page->assign('lists_and_groups', $list_and_groups);
+  }
+}

--- a/templates/CRM/Group/Page/Group.extra.tpl
+++ b/templates/CRM/Group/Page/Group.extra.tpl
@@ -2,13 +2,7 @@
 {if $action eq 16}
     {literal}
     <script>
-    var  lists_and_groups;
-    CRM.api('Mailchimp', 'getlistsandgroups', {'sequential': 1},
-        {success: function(data) {
-            lists_and_groups = data.values;    
-          }
-        }
-    );
+    var lists_and_groups = {/literal}{$lists_and_groups}{literal};
     
     cj(document).ajaxComplete(function(event, xhr, settings){
         if (settings.url.indexOf("civicrm/ajax/grouplist") >= 0) {

--- a/templates/CRM/Mailchimp/Form/Setting.tpl
+++ b/templates/CRM/Mailchimp/Form/Setting.tpl
@@ -14,6 +14,13 @@
 	          </span>
           </td>
         </tr>
+        <tr class="crm-mailchimp-setting-security-key-block">
+          <td class="label">{$form.security_key.label}</td>
+          <td>{$form.security_key.html}<br/>
+      	    <span class="description">{ts}User Defined Key{/ts}
+	          </span>
+          </td>
+        </tr>
       </table>
     </div>
     <div class="crm-submit-buttons">

--- a/xml/Menu/Mailchimp.xml
+++ b/xml/Menu/Mailchimp.xml
@@ -13,4 +13,10 @@
     <title>Mailchimp Sync</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/mailchimp/webhook</path>
+    <page_callback>CRM_Mailchimp_Page_WebHook</page_callback>
+    <title>WebHook</title>
+    <access_arguments>make online contributions</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
User has to enter the security key whatever he prefers in the mailchim setting navigation in civi and same key has to be entered in webhook url setting for the list in mailchimp setting to validate the connection from the truster source
