### PR TITLE
get rid of CURLOPT_FOLLOWLOCATION errors

### DIFF
--- a/vendor/mailchimp/Mailchimp.php
+++ b/vendor/mailchimp/Mailchimp.php
@@ -253,7 +253,6 @@ class Mailchimp {
         $this->ch = curl_init();
         curl_setopt($this->ch, CURLOPT_USERAGENT, 'MailChimp-PHP/2.0.4');
         curl_setopt($this->ch, CURLOPT_POST, true);
-        curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($this->ch, CURLOPT_HEADER, false);
         curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->ch, CURLOPT_CONNECTTIMEOUT, 30);


### PR DESCRIPTION
According to Pete, Mailchimp doesn't actually return redirects from their API right now, making FOLLOWLOCATION unnecessary. While they work to come up with a permanent fix, the current advice is that we simply not set that option, so I removed the line.

See here for more info: https://github.com/mailchimp/mcapi2-php-examples/issues/2#issuecomment-44988859
