### PR TITLE
Removal of contact from Group in civi also removed from mailchimp

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -265,4 +265,29 @@ function mailchimp_civicrm_permission( &$permissions ) {
     'allow webhook posts' => $prefix . ts('allow webhook posts'),
   );  
 }
+
+function mailchimp_civicrm_post( $op, $objectName, $objectId, &$objectRef ) {
+  if ($op == 'delete' && $objectName == 'GroupContact') { 
+    $emailIds= array();
+    $contactIds = array();
+    $contactIds = $objectRef;
+    if (empty($contactIds)) {
+      return NULL;
+    }
+    if (!empty($contactIds)) {      
+      $contactIDs = implode(',', $contactIds); 
+      $query = "
+        SELECT ce.id FROM `civicrm_email` ce
+        LEFT JOIN civicrm_contact cc ON cc.id = ce.contact_id
+        WHERE ce.contact_id IN ($contactIDs) AND ce.id is not null";
+    
+      $dao = CRM_Core_DAO::executeQuery($query); 
+        
+      while ($dao->fetch()) {
+        $emailIds[] = $dao->id;
+      }
+    }
+    CRM_Mailchimp_Utils::deleteMCEmail($emailIds); 
+  }
+}
   


### PR DESCRIPTION
When contacts are removed from a group in civicrm, it removes those contacts in mailchimp too.
