### PR TITLE
Fixes smartgroup cache and defaultgroup

### DIFF
--- a/CRM/Mailchimp/Page/WebHook.php
+++ b/CRM/Mailchimp/Page/WebHook.php
@@ -127,6 +127,15 @@ class CRM_Mailchimp_Page_WebHook extends CRM_Core_Page {
       // Remove the contact from CiviCRM group
       if ($action == 'unsubscribe') {
         CRM_Contact_BAO_GroupContact::removeContactsFromGroup($contactID, $groupID, 'Admin', 'Removed');
+        $group           = new CRM_Contact_DAO_Group();
+        $group->id       = $groupID;
+        $group->find();
+        if($group->fetch()){
+        //Check smart groups  
+          if($group->saved_search_id){
+            CRM_Contact_BAO_GroupContactCache::remove($groupID);
+          }
+        }
       }
     }
   } 


### PR DESCRIPTION
Fixed the cache issue, When a contact is removed from mailchimp, It is removed immediately from the smart group in civicrm, 

Fixed the default group issue when a contact is created and assigned to no group in mailchimp, that contact should be put into the default group
