### PR TITLE
Fixes if civigroup assigned to list only

### DIFF
--- a/CRM/Mailchimp/Form/Pull.php
+++ b/CRM/Mailchimp/Form/Pull.php
@@ -188,8 +188,13 @@ class CRM_Mailchimp_Form_Pull extends CRM_Core_Form {
               }
             }
           }else {
-            // if a list doesn't have groups,assign the contact to default group
-            $groupContact[$defaultgroup][]  = $contactID;
+            // if a list doesn't have groups,assign the contact to a group if mapping present in civi otherwise to default group
+            $civiGroupID  = CRM_Mailchimp_Utils::getGroupIdForMailchimp($listid, FALSE, FALSE);
+            if(!empty($civiGroupID)) {
+              $groupContact[$civiGroupID][]   = $contactID;
+            } else {
+              $groupContact[$defaultgroup][]  = $contactID;
+            }
           }
         }
       }

--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -125,14 +125,20 @@ class CRM_Mailchimp_Utils {
   }
   
   static function getGroupIdForMailchimp($listID, $groupingID, $groupID) {
-    if (empty($listID) || empty($groupingID) || empty($groupID)) {
+    if (empty($listID)) {
       return NULL;
+    }
+    
+    if (!empty($groupingID) && !empty($groupID)) {
+      $whereClause = "mc_list_id = %1 AND mc_grouping_id = %2 AND mc_group_id = %3";
+    } else {
+      $whereClause = "mc_list_id = %1";
     }
 
     $query  = "
       SELECT  entity_id
       FROM    civicrm_value_mailchimp_settings mcs
-      WHERE   mc_list_id = %1 AND mc_grouping_id = %2 AND mc_group_id = %3";
+      WHERE   $whereClause";
     $params = 
         array(
           '1' => array($listID , 'String'),

--- a/templates/CRM/Mailchimp/Form/Setting.tpl
+++ b/templates/CRM/Mailchimp/Form/Setting.tpl
@@ -44,9 +44,16 @@
 <script type="text/javascript">
  cj(document).ready(function(){
     var URL = "{/literal}{$webhook_url}{literal}" + '&key=';
+    var content = cj('#security_key').val();
+    cj('#webhook_url').text(URL + content);
     cj("#security_key").on('keyup', function() {
       var focusedValue = cj(this).val();
       cj('#webhook_url').text(URL + focusedValue);
+    });
+    
+    cj("#security_key").blur(function(){
+        var content = cj('#security_key').val();
+        cj('#webhook_url').text(URL + content);
     });
  });
 


### PR DESCRIPTION
Fix: 1) If a civi group is assigned to mailchimp list only, not group in the mailchimp list, we need to put the contact to this group rather than default group
2) Show Webhook Key url with the default value in the security key text box
