### PR TITLE
issue #94: DB error Fix , with duplicate contact sync to mailchimp, 

### DIFF
--- a/CRM/Mailchimp/Form/Sync.php
+++ b/CRM/Mailchimp/Form/Sync.php
@@ -517,8 +517,8 @@ class CRM_Mailchimp_Form_Sync extends CRM_Core_Form {
 
       // we're ready to store this but we need a hash that contains all the info
       // for comparison with the hash created from the CiviCRM data (elsewhere).
-      //          email,           first name,      last name,      groupings
-      $hash = md5($email->email . $contact->first_name . $contact->last_name . $info);
+      //          emailId,          email,           first name,      last name,      groupings
+      $hash = md5($email->id . $email->email . $contact->first_name . $contact->last_name . $info);
       // run insert prepared statement
       $db->execute($insert, array($contact->id, $email->email, $contact->first_name, $contact->last_name, $hash, $info));
     }


### PR DESCRIPTION
To avoid the DB error while sync with duplicate contact, adding emailId in before hash created. to make unique hash.
