### PR TITLE
Fix #110 and #111 for undefined property and contact not being added to sub group

### DIFF
--- a/CRM/Mailchimp/Page/WebHook.php
+++ b/CRM/Mailchimp/Page/WebHook.php
@@ -120,8 +120,9 @@ class CRM_Mailchimp_Page_WebHook extends CRM_Core_Page {
      */
     $mcGroupings = array();
     foreach (empty($requestData['merges']['GROUPINGS']) ? array() : $requestData['merges']['GROUPINGS'] as $grouping) {
-      foreach (explode(', ', $grouping['groups']) as $group);
-      $mcGroupings[$grouping['id']][$group] = 1;
+      foreach (explode(', ', $grouping['groups']) as $group){
+        $mcGroupings[$grouping['id']][$group] = 1;
+      }
     }
 
     $groups = CRM_Mailchimp_Utils::getGroupsToSync(array(), $listID, $membership_only=FALSE);

--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -49,7 +49,7 @@ class CRM_Mailchimp_Utils {
     }
 
     $query  = "
-      SELECT  entity_id, mc_list_id, mc_grouping_id, mc_group_id, is_mc_update_grouping, cg.title as civigroup_title, cg.saved_search_id
+      SELECT  entity_id, mc_list_id, mc_grouping_id, mc_group_id, is_mc_update_grouping, cg.title as civigroup_title, cg.saved_search_id, cg.children
  FROM    civicrm_value_mailchimp_settings mcs
       INNER JOIN civicrm_group cg ON mcs.entity_id = cg.id
       WHERE $whereClause";


### PR DESCRIPTION
Fixes: 
1) The new contact is not being added to sub group in CiviCRM from mailchimp when new subscriber is added into mailchimp
2) Undefined property 'children' during sync
