### PR TITLE
Resubscribe if address is unsubscribed in mailchimp and added extra condition to avoid server crash

### DIFF
--- a/CRM/Mailchimp/Form/Setting.php
+++ b/CRM/Mailchimp/Form/Setting.php
@@ -63,7 +63,17 @@ class CRM_Mailchimp_Form_Setting extends CRM_Core_Form {
         'name' => ts('Save & Test'),
       ),
     );
-
+    $groups = CRM_Mailchimp_Utils::getGroupsToSync(array(), null, $membership_only = TRUE);
+    foreach ($groups as $group_id => $details) {
+      $list           = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
+      $webhookoutput  = $list->webhooks($details['list_id']);
+      if($webhookoutput[0]['sources']['api'] == 1) {
+        CRM_Mailchimp_Utils::checkDebug('CRM_Mailchimp_Form_Setting - API is set in Webhook setting for listID', $details['list_id']);
+        $listID = $details['list_id'];
+        CRM_Core_Session::setStatus(ts('API is set in Webhook setting for listID %1', array(1 => $listID)), ts('Error'), 'error');
+        break;
+      }
+    }
     // Add the Buttons.
     $this->addButtons($buttons);
   }

--- a/api/v3/Mailchimp.php
+++ b/api/v3/Mailchimp.php
@@ -178,6 +178,14 @@ function civicrm_api3_mailchimp_getcivicrmgroupmailchimpsettings($params) {
  * @throws API_Exception
  */ 
 function civicrm_api3_mailchimp_sync($params) {
+  $groups = CRM_Mailchimp_Utils::getGroupsToSync(array(), null, $membership_only = TRUE);
+  foreach ($groups as $group_id => $details) {
+    $list           = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
+    $webhookoutput  = $list->webhooks($details['list_id']);
+    if($webhookoutput[0]['sources']['api'] == 1) {
+      return civicrm_api3_create_error('civicrm_api3_mailchimp_sync -  API is set in Webhook setting for listID '.$details['list_id'].' Please uncheck API' );
+    }
+  }
   $result = $pullResult = array();
 	
 	// Do pull first from mailchimp to CiviCRM

--- a/info.xml
+++ b/info.xml
@@ -8,8 +8,8 @@
     <author>Deepak Srivastava, Kajan, Parvez Saleh and Rich Lott (Artful Robot)</author>
     <email>support@vedaconsulting.co.uk</email>
   </maintainer>
-  <releaseDate>2015-10-20</releaseDate>
-  <version>1.8.3</version>
+  <releaseDate>2015-11-18</releaseDate>
+  <version>1.8.4</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>


### PR DESCRIPTION
issue:- 

1. If contact is removed from smart group, it unsubscribes in Mailchimp and if we added that contact again in CIvi, it does not resubscribe in Mailchimp
2. Server crashes if API set in Mailchimp list webhook setting

FIx:- 
1. Throw error when executing scheduled job
2. Indicate user in Mailchimp setting page in Civi about API set in webhook setting