### PR TITLE
Suppress the error message that a user is already subscribed when edi…

### DIFF
--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -728,7 +728,11 @@ class CRM_Mailchimp_Utils {
 					$result = $list->subscribe($listID, array('email' => $email), $merge, $email_type='html', $double_optin=FALSE, $update_existing=FALSE, $replace_interests=TRUE, $send_welcome=FALSE);
 				}
 				catch (Exception $e) {
-					CRM_Core_Session::setStatus($e->getMessage());
+          // Don't display if the error is that we're already subscribed.
+          $message = $e->getMessage();
+          if ($message !== $email . ' is already subscribed to the list.') {
+            CRM_Core_Session::setStatus($message);
+          }
 				}
 				break;
 			case "unsubscribe":


### PR DESCRIPTION
…ting a contact

If you have a contact that's already a member of a group that sync to a Mailchimp lsit, every time you edit the contact, the extension tries to sync them up again.  This leads to an error message that the email address is already subscribed to the list.  This PR suppresses ONLY that error.

Note that this is different from issue #14.