### PR TITLE
Closes #188 - Reduced no of API calls in sync Mailchimp to CiviCRM.

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -300,10 +300,6 @@ function mailchimp_civicrm_pre( $op, $objectName, $id, &$params ) {
   );
 
   if($objectName == 'Email') {
-    $email = new CRM_Core_BAO_Email();
-    $email->id = $id;
-    $email->find(TRUE);
-
     // If about to delete an email in CiviCRM, we must delete it from Mailchimp
     // because we won't get chance to delete it once it's gone.
     //
@@ -313,9 +309,15 @@ function mailchimp_civicrm_pre( $op, $objectName, $id, &$params ) {
     // info, where what they might have wanted was to change their email
     // address.
     if( ($op == 'delete') ||
-        ($op == 'edit' && $params['on_hold'] == 0 && $email->on_hold == 0 && $params['is_bulkmail'] == 0)
+        ($op == 'edit' && $params['on_hold'] == 0 && $params['is_bulkmail'] == 0)
     ) {
-      CRM_Mailchimp_Utils::deleteMCEmail(array($id));
+      $email = new CRM_Core_BAO_Email();
+      $email->id = $id;
+      $email->find(TRUE);
+
+      if ($op == 'delete' || $email->on_hold == 0) {
+        CRM_Mailchimp_Utils::deleteMCEmail(array($id));
+      }
     }
   }
 


### PR DESCRIPTION
This patch

* detects the easy to match mailchimp contacts (whose e-mail address is unique in CiviCRM) using one query.
* does not call the Contact.Create API for those detected contacts if the existing name in CiviCRM matches the name in Mailchimp.

In our particular case, synching using the web interface still does not work (timeouts, I guess), but you can sync using the api and drush as follows:

    drush cvapi Mailchimp.sync

Now it is probably wise that someone reviews this patch before merging :-)