### PR TITLE
undefined index error fix

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -312,10 +312,12 @@ function mailchimp_civicrm_pre( $op, $objectName, $id, &$params ) {
     // @todo Note: However, this will delete a subscriber and lose reporting
     // info, where what they might have wanted was to change their email
     // address.
-    if( ($op == 'delete') ||
-        ($op == 'edit' && $params['on_hold'] == 0 && $email->on_hold == 0 && $params['is_bulkmail'] == 0)
-    ) {
-      CRM_Mailchimp_Utils::deleteMCEmail(array($id));
+    if((array_key_exists('on_hold', $params)) && array_key_exists('is_bulkmail', $params)) {
+      if (($op == 'delete') ||
+          ($op == 'edit' && $params['on_hold'] == 0 && $email->on_hold == 0 && $params['is_bulkmail'] == 0)
+      ) {
+        CRM_Mailchimp_Utils::deleteMCEmail(array($id));
+      }
     }
   }
 


### PR DESCRIPTION
![screen shot 2016-02-11 at 12 42 34](https://cloud.githubusercontent.com/assets/13077149/13434343/5e878384-dfcd-11e5-9d16-4c4f79e3b972.jpg)


I keep getting undefined index notice each time I submit a contribution on CiviCRM. Fixed by adding an if statement to check if this array index exists or not.