### PR TITLE
Fix for interesting Group

### DIFF
--- a/CRM/Mailchimp/Form/Sync.php
+++ b/CRM/Mailchimp/Form/Sync.php
@@ -567,7 +567,7 @@ class CRM_Mailchimp_Form_Sync extends CRM_Core_Form {
       // save in $info.
       $info = $default_info;
 
-      $contact_group_titles = explode(',', $contact['group'] );
+      $contact_group_titles = explode(',', $contact['groups'] );
       foreach ($contact_group_titles as $title) {
         $group_id = $title2gid[$title];
         if (in_array($group_id, $grouping_group_ids)) {


### PR DESCRIPTION
Line 550 Contact Get API returns as follows. Because 's' missing means no support of child/interesting  groups in civi

This is fixed now

[values] => Array
        (
            [721] => Array
                (
                    [contact_id] => 721
                    [do_not_email] => 0
                    [is_opt_out] => 0
                    [first_name] => KJTestPR193first
                    [last_name] => KJTestPR193last
                    [contact_is_deleted] => 0
                    [email_id] => 738
                    [email] => kajtestanoterpr193@vedaconsulting.co.uk
                    [on_hold] => 0
                    [groups] => KJTestAnotherPR04Smart,KJTestAn