### PR TITLE
fix for Invalid Mailchimp ID and version update

### DIFF
--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -747,6 +747,9 @@ class CRM_Mailchimp_Utils {
 		);
 	
 		$listID = $groupDetails['list_id'];
+    if (!$listID) {
+      return;
+    }
 		$grouping_id = $groupDetails['grouping_id'];
 		$group_id = $groupDetails['group_id'];
 		if (!empty($grouping_id) AND !empty($group_id)) {

--- a/info.xml
+++ b/info.xml
@@ -8,8 +8,8 @@
     <author>Deepak Srivastava, Kajan, Parvez Saleh and Rich Lott (Artful Robot)</author>
     <email>support@vedaconsulting.co.uk</email>
   </maintainer>
-  <releaseDate>2016-06-01</releaseDate>
-  <version>1.8.7</version>
+  <releaseDate>2016-06-20</releaseDate>
+  <version>1.8.8</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>


### PR DESCRIPTION
issue - invalid mailchimp id error
example log - Jun 18 18:15:54  [info] $Start-CRM_Mailchimp_Utils subscribeOrUnsubsribeToMailchimpList $groupDetails = Array
(
    [list_id] => 
    [grouping_id] => 
    [group_id] => 
    [is_mc_update_grouping] => 
    [group_name] => 
    [grouping_name] => 
    [civigroup_title] => New wedding couple memberships
    [civigroup_uses_cache] => 1
)

After this code calles subscribe api without list id which causes this error