### PR TITLE
Generate valid (-looking) emails, irrespective of CIVICRM_UF_BASEURL

### DIFF
--- a/tests/integration/MailchimpApiIntegrationBase.php
+++ b/tests/integration/MailchimpApiIntegrationBase.php
@@ -279,15 +279,18 @@ class MailchimpApiIntegrationBase extends \PHPUnit_Framework_TestCase {
    *
    */
   public static function createTestContact(&$contact) {
+    $url_parts = parse_url(CIVICRM_UF_BASEURL);
+    $contact['email'] = strtolower($contact['first_name'] . '.' . $contact['last_name']) . '@' . $url_parts['host'];
+    $contact['subscriber_hash'] = md5(strtolower($contact['email']));
     $domain = preg_replace('@^https?://([^/]+).*$@', '$1', CIVICRM_UF_BASEURL);
-    $email = strtolower($contact['first_name'] . '.' . $contact['last_name']) . '@' . $domain;
+
     $contact['email'] = $email;
     $contact['subscriber_hash'] = md5(strtolower($email));
     $result = civicrm_api3('Contact', 'get', ['sequential' => 1,
       'first_name' => $contact['first_name'],
       'last_name'  => $contact['last_name'],
-      'email'      => $email,
-      ]);
+      'email'      => $contact['email'],
+    ]);
 
     if ($result['count'] == 0) {
       // Create the contact.
@@ -296,7 +299,7 @@ class MailchimpApiIntegrationBase extends \PHPUnit_Framework_TestCase {
         'first_name' => $contact['first_name'],
         'last_name'  => $contact['last_name'],
         'api.Email.create' => [
-          'email'      => $email,
+          'email'      => $contact['email'],
           'is_bulkmail' => 1,
           'is_primary' => 1,
         ],


### PR DESCRIPTION
Refs #234.

Regardless of whether CIVICRM_UF_BASEURL contains a port, the generated emails should at least look valid.
