### PR TITLE
Fixed warnings when running Mailchimp.pushsync via the command line with drush

### DIFF
--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -1464,7 +1464,7 @@ class CRM_Mailchimp_Sync {
   /**
    * There's probably a better way to do this.
    */
-  public static function runSqlReturnAffectedRows($sql, $params) {
+  public static function runSqlReturnAffectedRows($sql, $params = array()) {
     $dao = new CRM_Core_DAO();
     $q = CRM_Core_DAO::composeQuery($sql, $params);
     $result = $dao->query($q);

--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -182,7 +182,6 @@ class CRM_Mailchimp_Sync {
     }
 
     // Tidy up.
-    fclose($handle);
     $db->freePrepared($insert);
     return $collected;
   }


### PR DESCRIPTION
I think it is a leftover from the old way the API was accessed.