### PR TITLE
Refs #240 - Works around API changes in CiviCRM 4.7.11

### DIFF
--- a/CRM/Mailchimp/Page/WebHook.php
+++ b/CRM/Mailchimp/Page/WebHook.php
@@ -435,7 +435,7 @@ class CRM_Mailchimp_Page_WebHook extends CRM_Core_Page {
 
     // Now get a list of all the groups they *are* in.
     $result = civicrm_api3('Contact', 'getsingle', ['return' => 'group', 'contact_id' => $this->contact_id]);
-    $is_in = CRM_Mailchimp_Utils::splitGroupTitles($result['groups'], $this->sync->interest_group_details);
+    $is_in = CRM_Mailchimp_Utils::getGroupIds($result['groups'], $this->sync->interest_group_details);
 
     // Finally loop all the mapped interest groups and process any differences.
     foreach ($this->sync->interest_group_details as $group_id => $details) {

--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -857,7 +857,7 @@ class CRM_Mailchimp_Sync {
    */
   public function getComparableInterestsFromCiviCrmGroups($groups, $mode) {
     $civi_groups = $groups
-      ? array_flip(CRM_Mailchimp_Utils::splitGroupTitles($groups, $this->interest_group_details))
+      ? array_flip(CRM_Mailchimp_Utils::getGroupIds($groups, $this->interest_group_details))
       : [];
     $info = [];
     foreach ($this->interest_group_details as $civi_group_id => $details) {
@@ -1001,7 +1001,7 @@ class CRM_Mailchimp_Sync {
       'sequential' => 1
       ]);
 
-    $in_groups = CRM_Mailchimp_Utils::splitGroupTitles($contact['groups'], $this->group_details);
+    $in_groups = CRM_Mailchimp_Utils::getGroupIds($contact['groups'], $this->group_details);
     $currently_a_member = in_array($this->membership_group_id, $in_groups);
 
     if (empty($contact['email'])) {

--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -25,6 +25,25 @@ class CRM_Mailchimp_Utils {
   public static $post_hook_enabled = TRUE;
 
   /**
+   * Returns the group IDs corresponding to the group information returned
+   * by the CiviCRM API.
+   *
+   * The behaviour of the API changed in CiviCRM 4.7.11, see issue #240.
+   *
+   * @param string $api_group_result As output by the CiviCRM api for a contact
+   * when you request the 'group' output (which comes in a key called 'groups').
+   * @param array $group_details As from CRM_Mailchimp_Utils::getGroupsToSync
+   * but only including groups you're interested in.
+   * @return array CiviCRM groupIds.
+   */
+  public static function getGroupIds($api_group_result, $group_details) {
+    if (version_compare(CRM_Utils_System::version(), '4.7.11', '<')) {
+      return self::splitGroupTitles($api_group_result, $group_details);
+    }
+    return array_filter(explode(',', $api_group_result));
+  }
+
+  /**
    * Split a string of group titles into an array of groupIds.
    *
    * The Contact:get API is the only place you can get a list of all the groups

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -557,7 +557,7 @@ function mailchimp_civicrm_post( $op, $objectName, $objectId, &$objectRef ) {
       // find membership group, then find out if the contact is in that group.
       $membership_group_details = CRM_Mailchimp_Utils::getGroupsToSync(array(), $list_id, TRUE);
       $result = civicrm_api3('Contact', 'getsingle', ['return'=>'group','contact_id'=>$objectRef[0]]);
-      if (!CRM_Mailchimp_Utils::splitGroupTitles($result['groups'], $membership_group_details)) {
+      if (!CRM_Mailchimp_Utils::getGroupIds($result['groups'], $membership_group_details)) {
         // This contact is not in the membership group, so don't bother telling
         // Mailchimp about a change in their interests.
         return;

--- a/tests/integration/MailchimpApiIntegrationTest.php
+++ b/tests/integration/MailchimpApiIntegrationTest.php
@@ -840,7 +840,7 @@ class MailchimpApiIntegrationTest extends MailchimpApiIntegrationBase {
       // Store the new contact id in the fixture to enable clearup.
       static::$civicrm_contact_1['contact_id'] = (int) $result['contact_id'];
       // Check they're in the membership group.
-      $in_groups = CRM_Mailchimp_Utils::splitGroupTitles($result['groups'], $sync->group_details);
+      $in_groups = CRM_Mailchimp_Utils::getGroupIds($result['groups'], $sync->group_details);
       $this->assertContains(static::$civicrm_group_id_membership, $in_groups, "New contact was not in membership group, but should be.");
       $this->assertContains(static::$civicrm_group_id_interest_1, $in_groups, "New contact was not in interest group 1, but should be.");
     }


### PR DESCRIPTION
Hey,

Here is a pull request that works around the API change that was mentioned in issue #240. It just checks the CiviCRM version number to find out how the API group result should be handled.
