### PR TITLE
Update for recent file rename.

### DIFF
--- a/tests/integration/integration-test-bootstrap.php
+++ b/tests/integration/integration-test-bootstrap.php
@@ -27,4 +27,4 @@ else {
 }
 // Bootstrap CiviCRM.
 civicrm_initialize();
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'MailchimpApiIntegrationBase.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . '../../CRM/Mailchimp/IntegrationTestBase.php';


### PR DESCRIPTION
Tests no longer work since a33d5a9, this should fix bootstrapping tests at least.
