### PR TITLE
Fix memory issue for huge batches.

### DIFF
--- a/CRM/Mailchimp/Api3.php
+++ b/CRM/Mailchimp/Api3.php
@@ -132,8 +132,11 @@ class CRM_Mailchimp_Api3 {
    *
    * It quicker to run small ops directly for <15 items.
    *
+   * @param array $batch - operations to batch. By reference to save memory.
+   * @param string $method
+   * @return the result of the last Mailchimp API call.
    */
-  public function batchAndWait(Array $batch, $method=NULL) {
+  public function batchAndWait(Array &$batch, $method=NULL) {
     // This can take a long time...
     set_time_limit(0);
 
@@ -198,9 +201,12 @@ class CRM_Mailchimp_Api3 {
    * Sends a batch request.
    *
    * @param array batch array of arrays which contain three values: the method,
-   * the path (e.g. /lists) and the data describing a set of requests.
+   *   the path (e.g. /lists) and the data describing a set of requests.
+   *   We pass it by reference to save memory.
+   *
+   * @return array The result of the Mailchimp API call.
    */
-  public function makeBatchRequest(Array $batch) {
+  public function makeBatchRequest(Array &$batch) {
     $ops = [];
     foreach ($batch as $request) {
       $op = ['method' => strtoupper($request[0]), 'path' => $request[1]];
@@ -214,7 +220,8 @@ class CRM_Mailchimp_Api3 {
       }
       $ops []= $op;
     }
-    $result = $this->post('/batches', ['operations' => $ops]);
+    // Reference to $ops to save memory.
+    $result = $this->post('/batches', ['operations' => &$ops]);
 
     return $result;
   }

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -4,6 +4,9 @@ require_once 'mailchimp.civix.php';
 require_once 'vendor/mailchimp/Mailchimp.php';
 require_once 'vendor/mailchimp/Mailchimp/Lists.php';
 
+// Limit the size of a request batch to mailchimp, to avoid memory
+// problems.
+define("MAILCHIMP_MAX_REQUEST_BATCH_SIZE", 500);
 
 /**
  * Implementation of hook_civicrm_config


### PR DESCRIPTION
If for some reasons you needed to batch thousands of requests
for the Mailchimp API, the extension hit the php_memory_limit.
So I now restrict the size of batches to 500 requests.