### PR TITLE
Document the webhook permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ are also sensible practise.
 2. Unzip / untar the package and place it in your configured extensions directory.
 3. When you reload the Manage Extensions page the new “Mailchimp” extension should be listed with an Install link.
 4. Proceed with install.
+5. Grant the 'Mailchimp: allow webhook posts' for the the anonymous user so that Mailchimp can webhooks can be properly configured.
 
 Before the extension can be used you must set up your API keys. To get your
 Mailchimp account's API you should follow [Mailchimp's


### PR DESCRIPTION
I don't think this permission makes much sense (see https://github.com/veda-consulting/uk.co.vedaconsulting.mailchimp/issues/232) but given the amount of people that trip up on it, it should at least be documented.

Great extension though :)