### PR TITLE
#262 - Fix for Manage Groups table columns issue on AJAX refresh

### DIFF
--- a/templates/CRM/Group/Page/Group.extra.tpl
+++ b/templates/CRM/Group/Page/Group.extra.tpl
@@ -10,8 +10,10 @@ function mailchimpGroupsPageAlter() {
     return;
   }
   // Add header.
-  cj('table.crm-group-selector thead th.crm-group-name').after(
-    '<th class="crm-mailchimp">Mailchimp Sync</th>');
+  // FIX ME - adding mailchimp sync as second column causes issue when the datatable is updated using AJAX by newer version CiviCRM, hence appending mailchimp sync as last column
+  if(cj("table.crm-group-selector thead th.crm-mailchimp").length === 0) {
+    cj('table.crm-group-selector thead tr').append('<th class="crm-mailchimp">Mailchimp Sync</th>');
+  }
   rows.each(function() {
     var row = cj(this);
     var group_id_index = 'id' + row.data('id');
@@ -19,13 +21,20 @@ function mailchimpGroupsPageAlter() {
     if (mailchimp_groups[group_id_index]) {
       mailchimp_td.text(mailchimp_groups[group_id_index]);
     }
-    row.find('td.crm-group-name').after(mailchimp_td);
+    // FIX ME - adding mailchimp sync as second column causes issue when the datatable is updated using AJAX by newer version CiviCRM, hence appending mailchimp sync as last column
+    row.append(mailchimp_td);
   });
 }
 {/literal}
 {if $action eq 16}
 {* action 16 is VIEW, i.e. the Manage Groups page.*}
-CRM.$(mailchimpGroupsPageAlter);
+{* GK03082017 Group search func uses Ajax to update the datatable, hence triggerring mailchimpGroupsPageAlter func everytime the table redraws to ensure mailchimp related columns are added*}
+  {literal}
+    var dataTable = cj('table.crm-group-selector');
+    dataTable.on( 'draw.dt', function () {
+      CRM.$(mailchimpGroupsPageAlter);
+    });
+  {/literal}
 {/if}
 </script>
 


### PR DESCRIPTION
Appending Mailchimp Sync header and column into last column as inserting these into second column causes columns to be misplaced during AJAX refresh