### PR TITLE
#241 Make sync from Mailchimp -> Civi work with multiple mailchimp groups (api v3?)

### DIFF
--- a/CRM/Mailchimp/Page/WebHook.php
+++ b/CRM/Mailchimp/Page/WebHook.php
@@ -74,7 +74,7 @@ class CRM_Mailchimp_Page_WebHook extends CRM_Core_Page {
    * Methods may return data for mailchimp, or may throw RuntimeException
    * objects, the error code of which will be used for the response.
    * So you can throw a `RuntimeException("Invalid webhook configuration", 500);`
-   * to tell mailchimp the webhook failed, but you can equally throw a 
+   * to tell mailchimp the webhook failed, but you can equally throw a
    * `RuntimeException("soft fail", 200)` which will not tell Mailchimp there
    * was any problem. Mailchimp retries if there was a problem.
    *
@@ -431,7 +431,7 @@ class CRM_Mailchimp_Page_WebHook extends CRM_Core_Page {
   public function updateInterestsFromMerges() {
 
     // Get a list of CiviCRM group Ids that this contact should be in.
-    $should_be_in = $this->sync->splitMailchimpWebhookGroupsToCiviGroupIds($this->request_data['merges']['INTERESTS']);
+    $should_be_in = $this->sync->convertMailchimpWebhookGroupsToCiviGroupIds($this->request_data['merges']['GROUPINGS']);
 
     // Now get a list of all the groups they *are* in.
     $result = civicrm_api3('Contact', 'getsingle', ['return' => 'group', 'contact_id' => $this->contact_id]);

--- a/CRM/Mailchimp/Sync.php
+++ b/CRM/Mailchimp/Sync.php
@@ -32,6 +32,10 @@ class CRM_Mailchimp_Sync {
    */
   protected $interest_group_details;
   /**
+   * As above but groupep by category.
+   */
+  protected $interest_group_details_by_category;
+  /**
    * The CiviCRM group id responsible for membership at Mailchimp.
    */
   protected $membership_group_id;
@@ -52,6 +56,16 @@ class CRM_Mailchimp_Sync {
     // Also cache without the membership group, i.e. interest groups only.
     $this->interest_group_details = $this->group_details;
     unset($this->interest_group_details[$this->membership_group_id]);
+
+    // for mailchimp API v3, we need a hierarchized interest group details (group by mailchimp id)
+    $group_details_by_category = array();
+    foreach ($this->interest_group_details as $civi_group_id => $details) {
+      if (!array_key_exists($details['category_id'], $group_details_by_category)) {
+        $group_details_by_category[$details['category_id']] = array();
+      }
+      $group_details_by_category[$details['category_id']][$civi_group_id] = $details;
+    }
+    $this->interest_group_details_by_category = $group_details_by_category;
   }
   /**
    * Getter.
@@ -952,6 +966,10 @@ class CRM_Mailchimp_Sync {
    */
   public function splitMailchimpWebhookGroupsToCiviGroupIds($group_input) {
     return CRM_Mailchimp_Utils::splitGroupTitlesFromMailchimp($group_input, $this->interest_group_details);
+  }
+
+  public function convertMailchimpWebhookGroupsToCiviGroupIds($group_input) {
+    return CRM_Mailchimp_Utils::convertMailchimpWebhookGroupsToCiviGroupIds($group_input, $this->interest_group_details_by_category);
   }
 
   /**

--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -107,6 +107,7 @@ class CRM_Mailchimp_Utils {
    * @return array CiviCRM groupIds.
    */
   public static function splitGroupTitlesFromMailchimp($group_input, $group_details) {
+
     // Split on commas, excluding those escaped with backslash.
     $interest_names = array_map(function($_) { return str_replace('\\,', ',', $_); },
       preg_split('/(?<!\\\\), /', $group_input));
@@ -122,6 +123,26 @@ class CRM_Mailchimp_Utils {
     }
     return $groups;
   }
+  /**
+   * Convert array GROUPINGS given by mailchimp and convert it into an array of groupIds.
+   *
+   * @param string $group_input As output by the Mailchimp api v3.
+   * @param array $group_details_by_category As from CRM_Mailchimp_Utils::getGroupsToSync but grouped
+   * but only including groups you're interested in and grouped by category.
+   * @return array CiviCRM groupIds.
+   */
+  public static function convertMailchimpWebhookGroupsToCiviGroupIds($group_input, $group_details_by_category) {
+    // Mailchimp API v3 -> groups are in an array now
+    $groups = [];
+
+    // search on every mailchimp list for groups that could correspond in civicrm
+    foreach ($group_input as $mclist) {
+      $ng = self::splitGroupTitlesFromMailchimp($mclist['groups'], $group_details_by_category[$mclist['unique_id']]);
+      $groups = array_merge($groups, $ng);
+    }
+    return $groups;
+  }
+
   /**
    * Returns the webhook URL.
    */


### PR DESCRIPTION
This patch allows to take advantage of the new structure sent by mailchimp regarding the groups in Mailchimp list. It is stored in ['merge']['GROUPINGS'] instead of ['merge']['INTERESTS'].
Groupings contains all the groups contrary to Interests that contains only the first group of a Mailchimp list.

I don't see the need to keep backward compatibility (the ability to read Interests if Groupings is missing) because I think Groupings is the new way of doing in api v3 and couldn't be missing. 
I'm no expert of Mailchimp though so if someone can confirm that, it could be great.
