### PR TITLE
Make configureList always return an array

### DIFF
--- a/CRM/Mailchimp/Utils.php
+++ b/CRM/Mailchimp/Utils.php
@@ -280,6 +280,7 @@ class CRM_Mailchimp_Utils {
       ],
     ];
     $verb = $dry_run ? 'Need to change ' : 'Changed ';
+    $messages = array();
     try {
       $result = $api->get("/lists/$list_id/webhooks");
       $webhooks = empty($result->data->webhooks) ? NULL : $result->data->webhooks;
@@ -317,7 +318,7 @@ class CRM_Mailchimp_Utils {
 
         if (empty($messages)) {
           // All fine.
-          return;
+          return $messages;
         }
 
         if (!$dry_run) {


### PR DESCRIPTION
The result of configureLists is immediately used in a foreach() in a couple of places without checking it's an array. This causes warnings like

>Warning: Invalid argument supplied for foreach() in CRM_Mailchimp_Utils::checkGroupsConfig() (line 228 of uk.co.vedaconsulting.mailchimp/CRM/Mailchimp/Utils.php).