### PR TITLE
Adds permission for push and pull pages

### DIFF
--- a/CRM/Mailchimp/Permission.php
+++ b/CRM/Mailchimp/Permission.php
@@ -9,15 +9,16 @@ class CRM_Mailchimp_Permission extends CRM_Core_Permission {
    * @return array Keyed by machine names with human-readable labels for values
    */
   public static function getMailchimpPermissions() {
- 
+
   $prefix = ts('Mailchimp') . ': '; // name of extension or module
   return array(
- 'allow webhook posts' => $prefix . ts('allow webhook posts'),
+  'allow webhook posts' => $prefix . ts('allow webhook posts'),
+  'allow Mailchimp sync' =>$prefix . ts('allow Mailchimp sync'),
   );
   }
 
   /**
-   * Given a permission string or array, check for access requirements. 
+   * Given a permission string or array, check for access requirements.
    * if this is a permissions-challenged Joomla instance, don't enforce
    * CiviMailchimp-defined permissions.
    *

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -445,7 +445,7 @@ function mailchimp_civicrm_navigationMenu(&$params){
           'parentID'  => $parentId,
           'operator'  => NULL,
           'navID'     => $mailChimpsyncId,
-          'permission'=> 'administer CiviCRM',
+          'permission'=> 'administer CiviCRM,allow Mailchimp sync',
         ),
   );
   $params[$parentId]['child'][$mailChimpPullId] = array(
@@ -457,7 +457,7 @@ function mailchimp_civicrm_navigationMenu(&$params){
           'parentID'  => $parentId,
           'operator'  => NULL,
           'navID'     => $mailChimpPullId,
-          'permission'=> 'administer CiviCRM',
+          'permission'=> 'administer CiviCRM,allow Mailchimp sync',
         ),
   );
 }

--- a/xml/Menu/Mailchimp.xml
+++ b/xml/Menu/Mailchimp.xml
@@ -10,7 +10,7 @@
     <path>civicrm/mailchimp/sync</path>
     <page_callback>CRM_Mailchimp_Form_Sync</page_callback>
     <title>Mailchimp Push Sync: update Mailchimp from CiviCRM</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;allow Mailchimp sync</access_arguments>
   </item>
   <item>
     <path>civicrm/mailchimp/webhook</path>
@@ -23,7 +23,7 @@
     <path>civicrm/mailchimp/pull</path>
     <page_callback>CRM_Mailchimp_Form_Pull</page_callback>
     <title>Mailchimp Pull Sync: update CiviCRM from Mailchimp</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;allow Mailchimp sync</access_arguments>
   </item>
   <item>
    <path>civicrm/mailchimp/generate/webhookkey</path>


### PR DESCRIPTION
### Before
Only users with permission 'administer CiviCRM' can access push and pull pages.
### After
Adds one permission called 'allow Mailchimp sync'. Users with this permission will be able to access push and pull pages.
### Note
Permission 'access CiviMail' will be required for menu items displaying.


Agileware Ref: CIVICRM-1200