### PR TITLE
Fix #325 - remove log table on uninstall

### DIFF
--- a/sql/auto_uninstall.sql
+++ b/sql/auto_uninstall.sql
@@ -1,5 +1,6 @@
 -- drop custom value table
 DROP TABLE IF EXISTS civicrm_value_mailchimp_settings;
+DROP TABLE IF EXISTS log_civicrm_value_mailchimp_settings;
 
 -- drop custom set and their fields
 DELETE FROM `civicrm_custom_group` WHERE table_name = 'civicrm_value_mailchimp_settings';


### PR DESCRIPTION
The old code left the table `log_civicrm_value_mailchimp_settings` in existance after uninstall. Then if you tried to re-install the extension it would crash CiviCRM.

This PR adds a DROP TABLE IF EXISTS call on that table.