### PR TITLE
Fix missing label on template file

### DIFF
--- a/templates/CRM/Mailchimp/Form/Setting.tpl
+++ b/templates/CRM/Mailchimp/Form/Setting.tpl
@@ -8,7 +8,7 @@
 
       <table class="form-layout-compressed">
     	  <tr class="crm-mailchimp-setting-api-key-block">
-          <td class="label">{$form.api_key.label}</td>
+          <td class="label">{$form.mailchimp_api_key.label}</td>
           <td>{$form.mailchimp_api_key.html}<br/>
       	    <span class="description">{ts}API Key from Mail Chimp{/ts}
 	          </span>


### PR DESCRIPTION
Mailchimp Settings page does not output field label for API key when using Master branch

Before
---
No label for API key field
![screenshot](https://user-images.githubusercontent.com/49378827/70771201-5c721f80-1dc4-11ea-8203-dc8db4dfce99.png)

After
---
A label for API key field

Comment
---
Seems like the field name changed once and forgot to change the name in the template file.

Agileware ref: CIVICHIMP-9
