### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -12,10 +12,7 @@
   <version>2.0.3</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.4</ver>
-    <ver>4.5</ver>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>Developed by Veda Consulting LTD and Artful Robot.</comments>
   <civix>

--- a/templates/CRM/Mailchimp/Form/Setting.tpl
+++ b/templates/CRM/Mailchimp/Form/Setting.tpl
@@ -18,7 +18,7 @@
           <td class="label">{$form.mailchimp_security_key.label}</td>
           <td>{$form.mailchimp_security_key.html}
             &nbsp;&nbsp;
-            <input class="crm-button" type="button" name="generate_webhook_key" id="generate_webhook_key" onclick="generateWebhookKey();" value="{ts}Generate Key{/ts}" />
+            <input class="crm-button" type="button" name="generate_webhook_key" id="generate_webhook_key" onclick="generateWebhookKey();" value="{ts escape='htmlattribute'}Generate Key{/ts}" />
             <br/>
             <span class="description">{ts}Define a security key to be used with
             webhooks. e.g. a 12+ character random string of upper- and


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.