### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Mailchimp/IntegrationTestBase.php
+++ b/CRM/Mailchimp/IntegrationTestBase.php
@@ -439,7 +439,7 @@ class CRM_Mailchimp_IntegrationTestBase extends \PHPUnit_Framework_TestCase {
             civicrm_api3('Contact', 'getsingle', ['id' => $contact_id]);
             $result = civicrm_api3('Contact', 'delete', ['id' => $contact_id, 'skip_undelete' => 1]);
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             if ($e->getMessage() != 'Expected one Contact but found 0') {
               // That's OK, if it's already gone.
               throw $e;
@@ -643,7 +643,7 @@ class CRM_Mailchimp_IntegrationTestBase extends \PHPUnit_Framework_TestCase {
       }
       $this->fail($msg);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $x=1;
     }
   }

--- a/api/v3/Mailchimp.php
+++ b/api/v3/Mailchimp.php
@@ -16,7 +16,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getlists($params) {
   $api = CRM_Mailchimp_Utils::getMailchimpApi();
@@ -47,7 +47,7 @@ function civicrm_api3_mailchimp_getlists($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getinterests($params) {
   try {
@@ -88,7 +88,7 @@ function civicrm_api3_mailchimp_getinterests($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_pushsync($params) {
   // Do push from CiviCRM to mailchimp
@@ -116,7 +116,7 @@ function civicrm_api3_mailchimp_pushsync($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_pullsync($params) {
   // Do push from CiviCRM to mailchimp
@@ -145,7 +145,7 @@ function civicrm_api3_mailchimp_pullsync($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getmembercount($params) {
   $mcLists = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
@@ -170,7 +170,7 @@ function civicrm_api3_mailchimp_getmembercount($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getgroups($params) {
   $mcLists = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
@@ -200,7 +200,7 @@ function civicrm_api3_mailchimp_getgroups($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getgroupid($params) {
   $mcLists = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
@@ -230,7 +230,7 @@ function civicrm_api3_mailchimp_getgroupid($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getlistsandgroups($params) {
   $mcLists = new Mailchimp_Lists(CRM_Mailchimp_Utils::mailchimp());
@@ -259,7 +259,7 @@ function civicrm_api3_mailchimp_getlistsandgroups($params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */ 
 function civicrm_api3_mailchimp_getcivicrmgroupmailchimpsettings($params) {
   $groupIds = empty($params['ids']) ? array() : explode(',', $params['ids']);

--- a/tests/phpunit/CRM/Mailchimp/IntegrationTest.php
+++ b/tests/phpunit/CRM/Mailchimp/IntegrationTest.php
@@ -516,7 +516,7 @@ class CRM_Mailchimp_IntegrationTest extends \PHPUnit_Framework_TestCase implemen
             civicrm_api3('Contact', 'getsingle', ['id' => $contact_id]);
             $result = civicrm_api3('Contact', 'delete', ['id' => $contact_id, 'skip_undelete' => 1]);
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             if ($e->getMessage() != 'Expected one Contact but found 0') {
               // That's OK, if it's already gone.
               throw $e;


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.