### PR TITLE
Fix concatenated variables in ts()

### DIFF
--- a/CRM/Mailchimp/Form/Pull.php
+++ b/CRM/Mailchimp/Form/Pull.php
@@ -102,7 +102,9 @@ class CRM_Mailchimp_Form_Pull extends CRM_Core_Form {
       // Run Everything in the Queue via the Web.
       $runner->runAllViaWeb();
     } else {
-      CRM_Core_Session::setStatus(ts('Nothing to pull. Make sure mailchimp settings are configured in the <a href='.$setting_url.'>setting page</a>.'));
+      CRM_Core_Session::setStatus(ts('Nothing to pull. Make sure mailchimp settings are configured in the <a %1>setting page</a>.', [
+        1 => "href='$setting_url'"
+      ]));
     }
   }
 

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -242,8 +242,9 @@ function mailchimp_civicrm_validateForm( $formName, &$fields, &$files, &$form, &
       }
       if (!empty($otherGroups)) {
         $otherGroup = reset($otherGroups);
-        $errors['mailchimp_list'] = ts('There is already a CiviCRM group tracking this List, called "'
-          . $otherGroup['civigroup_title'].'"');
+        $errors['mailchimp_list'] = ts('There is already a CiviCRM group tracking this List, called "%1".', [
+          1 => $otherGroup['civigroup_title'],
+        ]);
       }
     }
   }
@@ -274,8 +275,9 @@ function mailchimp_civicrm_validateForm( $formName, &$fields, &$files, &$form, &
           list($mc_grouping_id, $mc_group_id) = explode('|', $fields['mailchimp_group']);
           foreach($otherGroups as $otherGroup) {
             if ($otherGroup['group_id'] == $mc_group_id) {
-              $errors['mailchimp_group'] = ts('There is already a CiviCRM group tracking this interest grouping, called "'
-                . $otherGroup['civigroup_title'].'"');
+              $errors['mailchimp_group'] = ts('There is already a CiviCRM group tracking this interest grouping, called "%1".', [
+                1 => $otherGroup['civigroup_title'],
+              ]);
             }
           }
         }


### PR DESCRIPTION
The ts() function does not support concatenated variables.

See https://docs.civicrm.org/dev/en/latest/translation/#best-practices