### PR TITLE
Remove deprecated curl_close

### DIFF
--- a/CRM/Mailchimp/Api3.php
+++ b/CRM/Mailchimp/Api3.php
@@ -345,7 +345,6 @@ class CRM_Mailchimp_Api3 {
       curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
       $result = curl_exec($curl);
       $info = curl_getinfo($curl);
-      curl_close($curl);
     }
     else {
       $callback = $this->mock_curl;

--- a/CRM/Mailchimp/Form/Setting.php
+++ b/CRM/Mailchimp/Form/Setting.php
@@ -214,7 +214,6 @@ class CRM_Mailchimp_Form_Setting extends CRM_Core_Form {
 
     $response = curl_exec($curl);
     $info = curl_getinfo($curl);
-    curl_close($curl);
 
     return ($info['http_code'] != 200) ? FALSE : TRUE;
   }


### PR DESCRIPTION
This function is deprecated as of php 8.0 and does nothing.
See https://www.php.net/manual/en/function.curl-close.php